### PR TITLE
Add cursor to track current typing location

### DIFF
--- a/frontend/src/components/Cursor.jsx
+++ b/frontend/src/components/Cursor.jsx
@@ -1,0 +1,26 @@
+export default function Cursor({ wordsObject, wordIndex, letterIndex }) {
+  let prevWordsCharCount = 0;
+  let spacesCount = wordIndex;
+
+  for (let i = 0; i < wordIndex; i++) {
+    prevWordsCharCount += Math.max(
+      wordsObject[i].word.length,
+      wordsObject[i].typed.length,
+    );
+  }
+
+  const style = {
+    top: '0px',
+    left: `calc(6px
+      + (14.4px * ${letterIndex})
+      + (14.4px * ${prevWordsCharCount})
+      + (8px * ${spacesCount}))`,
+  };
+
+  return (
+    <div
+      className="relative w-1 h-8 rounded animate-blink bg-gray-500"
+      style={style}
+    ></div>
+  );
+}

--- a/frontend/src/components/Cursor.jsx
+++ b/frontend/src/components/Cursor.jsx
@@ -1,6 +1,15 @@
-export default function Cursor({ wordsObject, wordIndex, letterIndex }) {
+export default function Cursor({
+  wordsObject,
+  wordIndex,
+  letterIndex,
+  containerWidth,
+}) {
   let prevWordsCharCount = 0;
   let spacesCount = wordIndex;
+  let wordRowMap = {};
+  let rowOffsets = { 0: 0 };
+  let row = 0;
+  let sumWidth = 0;
 
   for (let i = 0; i < wordIndex; i++) {
     prevWordsCharCount += Math.max(
@@ -9,17 +18,37 @@ export default function Cursor({ wordsObject, wordIndex, letterIndex }) {
     );
   }
 
+  for (let i = 0; i < wordsObject.length; i++) {
+    const wordLength = Math.max(
+      wordsObject[i].word.length,
+      wordsObject[i].typed.length,
+    );
+    const wordSpacing = (wordLength + 1) * 14.4; // 14.4px per character + one space
+    sumWidth += wordSpacing;
+
+    if (sumWidth > containerWidth) {
+      row += 1;
+      rowOffsets[row] = sumWidth - wordSpacing + rowOffsets[row - 1];
+      sumWidth = wordSpacing;
+    }
+
+    wordRowMap[i] = row;
+  }
+
+  // need to use style prop and perform CSS calc() operations in template
+  // literal, otherwise calc() doesn't resolve
   const style = {
-    top: '0px',
-    left: `calc(6px
+    top: `calc(32px * ${wordRowMap[wordIndex]})`,
+    left: `calc(-2px
       + (14.4px * ${letterIndex})
       + (14.4px * ${prevWordsCharCount})
-      + (8px * ${spacesCount}))`,
+      + (14.4px * ${spacesCount})
+      - ${rowOffsets[wordRowMap[wordIndex]]}px)`,
   };
 
   return (
     <div
-      className="relative w-1 h-8 rounded animate-blink bg-gray-500"
+      className="absolute w-1 h-8 rounded animate-blink bg-gray-500"
       style={style}
     ></div>
   );

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Word from './Word';
 import Stats from './Stats.jsx';
+import Cursor from './Cursor.jsx';
 
 const TypingTest = () => {
   const words = [
@@ -155,6 +156,11 @@ const TypingTest = () => {
         {isTestDone && <h2>Test done!</h2>}
         <h2>Typing Area</h2>
         <div className="flex justify-start flex-wrap">
+          <Cursor
+            wordsObject={wordsObject}
+            wordIndex={wordIndex}
+            letterIndex={letterIndex}
+          />
           {wordsObject.map((wordObject, index) => {
             return (
               <Word

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -39,7 +39,7 @@ const TypingTest = () => {
 
       if (!isTestStarted) {
         setIsTestStarted(true);
-        setTime({ ...time, start: new Date()});
+        setTime({ ...time, start: new Date() });
       }
 
       // if user at start of word and types space, do nothing
@@ -54,7 +54,7 @@ const TypingTest = () => {
         // if already on last word, end typing test
         if (newWordIndex >= wordsObject.length) {
           setIsTestDone(true);
-          setTime({ ...time, end: new Date()});
+          setTime({ ...time, end: new Date() });
           return;
         }
 
@@ -171,13 +171,15 @@ const TypingTest = () => {
             );
           })}
         </div>
-        {isTestDone && <Stats
-          wordsObject={wordsObject}
-          typedCharacters={typedCharacters}
-          typedErrors={typedErrors}
-          startTime={time.start}
-          endTime={time.end}
-        />}
+        {isTestDone && (
+          <Stats
+            wordsObject={wordsObject}
+            typedCharacters={typedCharacters}
+            typedErrors={typedErrors}
+            startTime={time.start}
+            endTime={time.end}
+          />
+        )}
       </div>
     </>
   );

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Word from './Word';
 import Stats from './Stats.jsx';
 import Cursor from './Cursor.jsx';
@@ -31,6 +31,9 @@ const TypingTest = () => {
   const [time, setTime] = useState({ start: null, end: null });
   const [typedCharacters, setTypedCharacters] = useState(0);
   const [typedErrors, setTypedErrors] = useState(0);
+
+  const ref = useRef(null);
+  const [width, setWidth] = useState(0);
 
   useEffect(() => {
     function handleKeydown(e) {
@@ -135,6 +138,18 @@ const TypingTest = () => {
     };
   }, [wordsObject, wordIndex, letterIndex, typedIndex, isTestDone]);
 
+  useEffect(() => {
+    setWidth(ref.current.offsetWidth);
+
+    const getwidth = () => {
+      setWidth(ref.current.offsetWidth);
+    };
+
+    window.addEventListener('resize', getwidth);
+
+    return () => window.removeEventListener('resize', getwidth);
+  }, []);
+
   return (
     <>
       <div className="flex flex-col justify-center items-center">
@@ -152,14 +167,19 @@ const TypingTest = () => {
           <p>start time: {JSON.stringify(time)} </p>
           <p>typed chars: {typedCharacters}</p>
           <p>typed errors: {typedErrors}</p>
+          <p>width: {width}</p>
         </div>
         {isTestDone && <h2>Test done!</h2>}
         <h2>Typing Area</h2>
-        <div className="flex justify-start flex-wrap">
+        <div
+          ref={ref}
+          className="relative flex justify-start flex-wrap max-w-prose border"
+        >
           <Cursor
             wordsObject={wordsObject}
             wordIndex={wordIndex}
             letterIndex={letterIndex}
+            containerWidth={width}
           />
           {wordsObject.map((wordObject, index) => {
             return (

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -117,7 +117,7 @@ const TypingTest = () => {
           setLetterIndex(newLetterIndex);
           return;
         }
-      } else {
+      } else if ('abcdefghijklmnopqrstuvwxyz'.includes(e.key)) {
         // even if keypress was wrong, capture what user typed
         let newWordsObject = [...wordsObject];
         let newLetterIndex = letterIndex + 1;

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -43,12 +43,12 @@ const TypingTest = () => {
       }
 
       // if user at start of word and types space, do nothing
-      if (typedIndex === 0 && (e.key === ' ' || e.keycode === 32)) {
+      if (typedIndex === 0 && e.key === ' ') {
         return;
       }
 
       // if user not at start of word and types space, go to next word
-      if (typedIndex > 0 && (e.key === ' ' || e.keycode === 32)) {
+      if (typedIndex > 0 && e.key === ' ') {
         let newWordIndex = wordIndex + 1;
 
         // if already on last word, end typing test
@@ -67,7 +67,7 @@ const TypingTest = () => {
       }
 
       // if user types backspace, remove previously typed character
-      if (e.key === 'Backspace' || e.keycode === 8) {
+      if (e.key === 'Backspace') {
         let newWordsObject = [...wordsObject];
         newWordsObject[wordIndex].typed = newWordsObject[wordIndex].typed.slice(
           0,

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -104,12 +104,12 @@ const TypingTest = () => {
           newWordsObject[wordIndex].typed === currentWord
         ) {
           setIsTestDone(true);
-          setTime({ ...time, end: new Date()});
+          setTime({ ...time, end: new Date() });
           return;
         }
 
         // if word not finished, set letter and its index
-        if (newLetterIndex < currentWord.length) {
+        if (newLetterIndex <= currentWord.length) {
           setLetterIndex(newLetterIndex);
           return;
         }

--- a/frontend/src/components/Word.jsx
+++ b/frontend/src/components/Word.jsx
@@ -31,7 +31,7 @@ export default function Word({ word, typed }) {
 
   return (
     <>
-      <div className="text-2xl font-mono mx-1">{renderLetters()}</div>
+      <div className="text-2xl font-mono mr-[14.4px]">{renderLetters()}</div>
     </>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,24 @@ import defaultTheme from 'tailwindcss/defaultTheme';
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      animation: {
+        blink: 'blink 1s infinite',
+      },
+      keyframes: {
+        blink: {
+          '0%': {
+            opacity: '0',
+          },
+          '50%': {
+            opacity: '1',
+          },
+          '100%': {
+            opacity: '0',
+          },
+        },
+      },
+    },
     fontFamily: {
       mono: ['JetBrainsMono-Regular', ...defaultTheme.fontFamily.mono],
     },


### PR DESCRIPTION
## Changes

### Major Changes
Add a cursor to show the user's current position in the typing test. The cursor knows when it's reached the end of a line and will travel back to the beginning of a new line once reached. The cursor is also responsive to window/container resizing and will position itself appropriately.

### Bug Fixes / Minor Changes
- Fix typo causing bug where next letter index wouldn't increment on the last letter of a word
- Use of `event.which` and `event.keycode` is deprecated, so remove mentions of those
- Miscellaneous formatting with prettier

## Why
The user should have feedback on their current position in the typing test that goes beyond letter coloring.

## How
The cursor is just an absolute position div in a relative position parent that specifies a `top` and `left` CSS property according to the current word index, letter index, and how many words have been completed already.

On every render, an object is populated with the word index as keys and the corresponding row as values based on a comparison to the current parent container's width. There's also an object that tracks the horizontal offset for a given row to bring the cursor back to the start of a new line.

## Notes
The code for determining what row a given word in the typing window will be on and how to offset the cursor horizontally is a bit messy, not to mention full of hard-coded values for the character width. `ch` units didn't seem to work, so there is an opportunity to refactor this to use relative units, which would be ideal.

For now, however, it works for various window/container widths and for different browser zoom levels.