### PR TITLE
Add timer and option to configure a timed test

### DIFF
--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -35,7 +35,11 @@ const TypingTest = () => {
   const [typedIndex, setTypedIndex] = useState(0);
   const [isTestDone, setIsTestDone] = useState(false);
   const [isTestStarted, setIsTestStarted] = useState(false);
-  const [time, setTime] = useState({ start: null, end: null });
+  const [time, setTime] = useState({
+    start: null,
+    end: null,
+  });
+  const [countdown, setCountdown] = useState(config.timedTestDuration);
   const [typedCharacters, setTypedCharacters] = useState(0);
   const [typedErrors, setTypedErrors] = useState(0);
 
@@ -157,6 +161,25 @@ const TypingTest = () => {
     return () => window.removeEventListener('resize', getwidth);
   }, []);
 
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setCountdown(() => {
+        if (config.isTimedTest && isTestStarted && !isTestDone)
+          return countdown - 1;
+        return countdown;
+      });
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [config.isTimedTest, countdown, isTestStarted, isTestDone]);
+
+  useEffect(() => {
+    if (countdown === 0 && !isTestDone) {
+      setTime({ ...time, end: new Date() });
+      setIsTestDone(true);
+    }
+  }, [countdown, setTime, time, setIsTestDone, isTestDone]);
+
   return (
     <>
       <div className="flex flex-col justify-center items-center">
@@ -176,6 +199,7 @@ const TypingTest = () => {
           <p>typed chars: {typedCharacters}</p>
           <p>typed errors: {typedErrors}</p>
           <p>width: {width}</p>
+          <p>countdown: {countdown} s</p>
         </div>
         {isTestDone && <h2>Test done!</h2>}
         <h2>Typing Area</h2>

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -23,6 +23,13 @@ const TypingTest = () => {
     })),
   );
 
+  const [config, setConfig] = useState({
+    isTimedTest: true,
+    timedTestDuration: 10, // seconds
+    isWordsTest: false,
+    wordsTestTarget: 25,
+  });
+
   const [wordIndex, setWordIndex] = useState(0);
   const [letterIndex, setLetterIndex] = useState(0);
   const [typedIndex, setTypedIndex] = useState(0);
@@ -155,6 +162,7 @@ const TypingTest = () => {
       <div className="flex flex-col justify-center items-center">
         <h2>Debug Info</h2>
         <div>
+          <p>config: {JSON.stringify(config)}</p>
           <p>words length: {words.length}</p>
           <p>word index: {wordIndex}</p>
           <p>words object: {JSON.stringify(wordsObject)}</p>


### PR DESCRIPTION
## Changes

### Major Changes
Add a timer that counts down every second. The timer starts only if the test has been configured as a timed typing test. When the timer reaches 0 seconds, the test is marked complete.

### Bug Fixes / Minor Changes
- Miscellaneous formatting with prettier

## Why
A timed typing test is one of the two common types of typing tests, the other being a test in which a target number of words are completed.

## How
The timer is implemented in a `useEffect` hook using `setInterval` which updates a state variable showing the remaining time, or the countdown. A separate `useEffect` call marks the test complete by watching the countdown and acting only when it has reached 0.

## Notes
I attempted to make the timer a separate component, but it ended up needing a lot of parameters passed to it to manage itself and then propagating changes upstream to the parent became complicated. So for now, the timer is bundled along with all the other state variables in the typing window.