### PR TITLE
Accuracy calcs

### DIFF
--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -23,8 +23,10 @@ export default function Stats ({ wordsObject, typedCharacters, typedErrors, star
   const wordsTyped = typedCharacters / 5; // standard to consider a 'word' to be any 5 characters
   const duration = (endTime.getTime() - startTime.getTime()) / 1000 / 60; // ms converted to min
   const rawWpm = Math.round(wordsTyped / duration);
-  const netWpm = Math.round((wordsTyped - errors) / duration);
-  const percentAccuracy = Math.round(((typedCharacters - typedErrors) / typedCharacters) * 100);
+  const netWpm = Math.round((wordsTyped - errors - extras - missed) / duration);
+  const percentAccuracy = Math.round(
+    ((typedCharacters - typedErrors - extras - missed) / typedCharacters) * 100,
+  );
 
   return (
     <>

--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -1,4 +1,10 @@
-export default function Stats ({ wordsObject, typedCharacters, typedErrors, startTime, endTime }) {
+export default function Stats({
+  wordsObject,
+  typedCharacters,
+  typedErrors,
+  startTime,
+  endTime,
+}) {
   let errors = 0;
   let extras = 0;
   let missed = 0;
@@ -32,10 +38,12 @@ export default function Stats ({ wordsObject, typedCharacters, typedErrors, star
     <>
       <div>
         <p>Test completed!</p>
-        <p>{typedCharacters}/{errors}/{extras}/{missed}</p>
+        <p>
+          {typedCharacters}/{errors}/{extras}/{missed}
+        </p>
         <p>raw wpm: {rawWpm}</p>
-        {(netWpm > 0) && <p>net wpm: {netWpm}</p>}
-        {(netWpm <= 0) && <p>net wpm: Invalid</p>}
+        {netWpm > 0 && <p>net wpm: {netWpm}</p>}
+        {netWpm <= 0 && <p>net wpm: Invalid</p>}
         <p>accuracy: {percentAccuracy}%</p>
       </div>
     </>


### PR DESCRIPTION
## Changes

### Major Changes
Update the WPM and accuracy calculations to include extra and missed characters.

### Bug Fixes / Minor Changes
- Miscellaneous formatting with prettier

## Why
For net WPM, it should consider all uncorrected errors, which would include extra or missed characters that were not corrected before moving onto the next word.

For accuracy, extra and missed characters are also included because extra characters were incorrectly typed when a space was expected and missed characters were incorrectly typed because a space was typed and the user then moved onto the next word.

## How
An update to the net WPM and accuracy calculations to include extra and missed character counts.

## Notes
The way the app works right now is that as soon as you type space, you are moved to the next word and cannot go back to make changes. So extra or missed characters are permanent once the user has moved on. I'm wondering if the net gain in WPM by just ignoring mistakes and moving on would be balanced out by having the ability to return to previous words and fixing mistakes. I think this is fine for now, and this matter is just me nit-picking.