### PR TITLE
Add counter to show completed words vs. total words

### DIFF
--- a/frontend/src/components/Counter.jsx
+++ b/frontend/src/components/Counter.jsx
@@ -1,0 +1,9 @@
+export default function Counter({ current, total }) {
+  return (
+    <>
+      <p>
+        {current}/{total}
+      </p>
+    </>
+  );
+}

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import Word from './Word';
 import Stats from './Stats.jsx';
 import Cursor from './Cursor.jsx';
+import Counter from './Counter.jsx';
 
 const TypingTest = () => {
   const words = [
@@ -171,6 +172,7 @@ const TypingTest = () => {
         </div>
         {isTestDone && <h2>Test done!</h2>}
         <h2>Typing Area</h2>
+        <Counter current={wordIndex} total={wordsObject.length} />
         <div
           ref={ref}
           className="relative flex justify-start flex-wrap max-w-prose border"


### PR DESCRIPTION
## Changes

### Major Changes
Adds a component that shows completed work count vs. total word count.

### Bug Fixes / Minor Changes
N/A

## Why
Basic feedback for the user if they are performing a target word count style typing test.

## How
A separate counter component that accepts current vs. total counts and displays them. The counts are based on the `wordIndex`, which tracks number of completed words nicely, and `wordsObject`, whose length as an array is the total number of words.

## Notes
`wordIndex` is not updated at the completion of the test, so it remains 1 short. But this is probably a non-issue if the typing window is hidden and instead replaced with the stats window at the completion of a test (not yet implemented).