### PR TITLE
Add buttons for setting typing test configuration

### DIFF
--- a/frontend/src/components/ConfigOptions.jsx
+++ b/frontend/src/components/ConfigOptions.jsx
@@ -1,0 +1,82 @@
+export default function ConfigOptions({
+  isTimedTest,
+  isWordsTest,
+  onClickHandleConfig,
+}) {
+  return (
+    <>
+      {isWordsTest && (
+        <div>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            words="10"
+            onClick={onClickHandleConfig}
+          >
+            10
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            words="25"
+            onClick={onClickHandleConfig}
+          >
+            25
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            words="50"
+            onClick={onClickHandleConfig}
+          >
+            50
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            words="100"
+            onClick={onClickHandleConfig}
+          >
+            100
+          </button>
+        </div>
+      )}
+      {isTimedTest && (
+        <div>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            duration="15"
+            onClick={onClickHandleConfig}
+          >
+            15
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            duration="30"
+            onClick={onClickHandleConfig}
+          >
+            30
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            duration="60"
+            onClick={onClickHandleConfig}
+          >
+            60
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            duration="120"
+            onClick={onClickHandleConfig}
+          >
+            120
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -3,6 +3,7 @@ import Word from './Word';
 import Stats from './Stats.jsx';
 import Cursor from './Cursor.jsx';
 import Counter from './Counter.jsx';
+import ConfigOptions from './ConfigOptions.jsx';
 
 const TypingTest = () => {
   const words = [
@@ -181,6 +182,29 @@ const TypingTest = () => {
     }
   }, [countdown, setTime, time, setIsTestDone, isTestDone]);
 
+  function handleTestMode(e) {
+    console.log(e.target.getAttribute('mode'));
+    const testMode = e.target.getAttribute('mode');
+    if (testMode === 'time') {
+      setConfig({ ...config, isTimedTest: true, isWordsTest: false });
+    } else if (testMode === 'word') {
+      setConfig({ ...config, isTimedTest: false, isWordsTest: true });
+    }
+  }
+
+  function handleConfigOptions(e) {
+    if (config.isTimedTest) {
+      setConfig({
+        ...config,
+        timedTestDuration: e.target.getAttribute('duration'),
+      });
+      setCountdown(Number(e.target.getAttribute('duration')));
+    }
+    if (config.isWordsTest) {
+      setConfig({ ...config, wordsTestTarget: e.target.getAttribute('words') });
+    }
+  }
+
   return (
     <>
       <div className="flex flex-col justify-center items-center">
@@ -203,6 +227,29 @@ const TypingTest = () => {
           <p>countdown: {countdown} s</p>
         </div>
         {isTestDone && <h2>Test done!</h2>}
+        <div>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            mode="time"
+            onClick={handleTestMode}
+          >
+            time
+          </button>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            mode="word"
+            onClick={handleTestMode}
+          >
+            words
+          </button>
+        </div>
+        <ConfigOptions
+          isTimedTest={config.isTimedTest}
+          isWordsTest={config.isWordsTest}
+          onClickHandleConfig={handleConfigOptions}
+        />
         <h2>Typing Area</h2>
         <Counter current={wordIndex} total={wordsObject.length} />
         <div


### PR DESCRIPTION
## Changes

### Major Changes
Add buttons to change the type of test and choose options for a given test (duration of timed test or number of words).

### Bug Fixes / Minor Changes
N/A

## Why
There should be an easy way to configure the typing test.

## How
Buttons are added for each of the types of tests (timed, words). Depending on which is active, a separate `ConfigOptions.jsx` component renders the options. Each option is a button with a custom attribute that handle functions read and set the config state object accordingly.

## Notes
N/A