### PR TITLE
Add fetch API and improve word generation for typing test

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import cookieParser from 'cookie-parser';
 import logger from 'morgan';
+import cors from 'cors';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,6 +12,11 @@ import { fileURLToPath } from 'url';
 
 const app = express();
 
+const corsOptions = {
+  origin: 'http://localhost:5173',
+};
+
+app.use('*', cors(corsOptions));
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/backend/data/hololive-en.json
+++ b/backend/data/hololive-en.json
@@ -30,6 +30,15 @@
     "mococo",
     "fuwamoco",
     "abyssgard",
+    "elizabeth",
+    "rose",
+    "bloodflame",
+    "gigi",
+    "murin",
+    "cecilia",
+    "immergreen",
+    "raora",
+    "panthera",
     "tsukumo",
     "sana"
   ]

--- a/backend/data/hololive-en.json
+++ b/backend/data/hololive-en.json
@@ -40,6 +40,25 @@
     "raora",
     "panthera",
     "tsukumo",
-    "sana"
+    "sana",
+    "reaper",
+    "phoenix",
+    "priestess",
+    "shark",
+    "detective",
+    "nephilim",
+    "kirin",
+    "warden",
+    "owl",
+    "rat",
+    "archiver",
+    "gem",
+    "demon",
+    "dog",
+    "queen",
+    "chaser",
+    "automaton",
+    "artist",
+    "speaker"
   ]
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "cookie-parser": "~1.4.4",
+        "cors": "^2.8.5",
         "debug": "~2.6.9",
         "express": "~4.16.1",
         "morgan": "~1.9.1"
@@ -196,6 +197,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -602,6 +615,14 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "express": "~4.16.1",
     "morgan": "~1.9.1"

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -6,7 +6,14 @@ import Counter from './Counter.jsx';
 import ConfigOptions from './ConfigOptions.jsx';
 
 const TypingTest = () => {
-  const words = [
+  const [config, setConfig] = useState({
+    isTimedTest: true,
+    timedTestDuration: 10, // seconds
+    isWordsTest: false,
+    wordsTestTarget: 25,
+  });
+
+  const [words, setWords] = useState([
     'the',
     'quick',
     'brown',
@@ -16,7 +23,7 @@ const TypingTest = () => {
     'the',
     'lazy',
     'dog',
-  ];
+  ]);
 
   const [wordsObject, setWordsObject] = useState(
     words.map((word) => ({
@@ -25,12 +32,6 @@ const TypingTest = () => {
     })),
   );
 
-  const [config, setConfig] = useState({
-    isTimedTest: true,
-    timedTestDuration: 10, // seconds
-    isWordsTest: false,
-    wordsTestTarget: 25,
-  });
 
   const [wordIndex, setWordIndex] = useState(0);
   const [letterIndex, setLetterIndex] = useState(0);

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -25,13 +25,49 @@ const TypingTest = () => {
     'dog',
   ]);
 
-  const [wordsObject, setWordsObject] = useState(
-    words.map((word) => ({
+  function getRandomWords(wordArray, targetNum) {
+    let randomizedWords = [];
+    let visitedIndices = [];
+
+    const wordLimit = Math.min(wordArray.length, targetNum);
+
+    for (let i = 0; i < wordLimit; i++) {
+      let index = Math.floor(Math.random() * wordArray.length);
+
+      while (visitedIndices.includes(index)) {
+        index = Math.floor(Math.random() * wordArray.length);
+      }
+
+      visitedIndices.push(index);
+      randomizedWords.push(wordArray[index]);
+    }
+
+    return randomizedWords;
+  }
+
+  async function handleGetWordList(e) {
+    const listName = e.target.getAttribute('list');
+    await fetch(`http://localhost:3000/${listName}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setWords(data.words);
+      })
+      .catch((err) => console.log(err));
+  }
+
+  function mapWords(words) {
+    const wordArray = words.map((word) => ({
       word: word,
       typed: '',
-    })),
-  );
+    }));
+    return wordArray;
+  }
 
+  const [wordsObject, setWordsObject] = useState(mapWords(words));
+
+  useEffect(() => {
+    setWordsObject(mapWords(getRandomWords(words, config.wordsTestTarget)));
+  }, [words, config.wordsTestTarget]);
 
   const [wordIndex, setWordIndex] = useState(0);
   const [letterIndex, setLetterIndex] = useState(0);
@@ -203,6 +239,9 @@ const TypingTest = () => {
     }
     if (config.isWordsTest) {
       setConfig({ ...config, wordsTestTarget: e.target.getAttribute('words') });
+      setWordsObject(
+        mapWords(getRandomWords(words, e.target.getAttribute('words'))),
+      );
     }
   }
 

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -290,6 +290,26 @@ const TypingTest = () => {
           isWordsTest={config.isWordsTest}
           onClickHandleConfig={handleConfigOptions}
         />
+        <div>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            list="english-100"
+            onClick={handleGetWordList}
+          >
+            English 100
+          </button>
+        </div>
+        <div>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            list="hololive-en"
+            onClick={handleGetWordList}
+          >
+            Hololive EN
+          </button>
+        </div>
         <h2>Typing Area</h2>
         <Counter current={wordIndex} total={wordsObject.length} />
         <div


### PR DESCRIPTION
## Changes

### Major Changes
Incorporate the fetch API to send GET requests for new word lists. Add buttons for each word list that triggers a fetch. Let word count configuration buttons trigger an update of `wordsObject` to refresh the list of words to type based on the desired word count.

### Bug Fixes / Minor Changes
- Add CORS to the backend with an allowance for the frontend running on the default Vite localhost address
- Add word list for hololive English (EN) related words

## Why
Regarding more word lists, user should have the option to try different word lists for the sake of variety. If there are many available, they should be stored on the server and sent to the user on-demand, so via fetch API.

Creation of `wordsObject` involved some steps that were being repeated when adapting its instantiation for use with the update of `words` with the fetch API. Breaking it up into functions made for more modular code and also allowed for use of its functionality in other areas, such as when changing the word count for the word test mode. Doing so updates `wordsObject`, but doesn't trigger a new fetch like it might've with the previous implementation.

## How
fetch is used inside a useEffect hook. Previous functionality of creating `wordsObject` was modularized by defining new functions as well as improved upon e.g. adding randomization to the words.

## Notes
Word count is currently dependent on the number of words being selected while in the word test mode. A timed test should have a steady stream of words added as needed as the user progresses through the test so that they don't run out of words to type. This should be addressed in the future.