### PR TITLE
Scroll typing window

### DIFF
--- a/frontend/src/components/Cursor.jsx
+++ b/frontend/src/components/Cursor.jsx
@@ -7,6 +7,7 @@ export default function Cursor({
 }) {
   let prevWordsCharCount = 0;
   let spacesCount = wordIndex;
+  const rowMultiplier = wordRowMap[wordIndex] === 0 ? 0 : 1;
 
   for (let i = 0; i < wordIndex; i++) {
     prevWordsCharCount += Math.max(
@@ -18,7 +19,7 @@ export default function Cursor({
   // need to use style prop and perform CSS calc() operations in template
   // literal, otherwise calc() doesn't resolve
   const style = {
-    top: `calc(32px * ${wordRowMap[wordIndex]})`,
+    top: `calc(32px * ${rowMultiplier})`,
     left: `calc(-2px
       + (14.4px * ${letterIndex})
       + (14.4px * ${prevWordsCharCount})

--- a/frontend/src/components/Cursor.jsx
+++ b/frontend/src/components/Cursor.jsx
@@ -2,37 +2,17 @@ export default function Cursor({
   wordsObject,
   wordIndex,
   letterIndex,
-  containerWidth,
+  wordRowMap,
+  rowOffsets,
 }) {
   let prevWordsCharCount = 0;
   let spacesCount = wordIndex;
-  let wordRowMap = {};
-  let rowOffsets = { 0: 0 };
-  let row = 0;
-  let sumWidth = 0;
 
   for (let i = 0; i < wordIndex; i++) {
     prevWordsCharCount += Math.max(
       wordsObject[i].word.length,
       wordsObject[i].typed.length,
     );
-  }
-
-  for (let i = 0; i < wordsObject.length; i++) {
-    const wordLength = Math.max(
-      wordsObject[i].word.length,
-      wordsObject[i].typed.length,
-    );
-    const wordSpacing = (wordLength + 1) * 14.4; // 14.4px per character + one space
-    sumWidth += wordSpacing;
-
-    if (sumWidth > containerWidth) {
-      row += 1;
-      rowOffsets[row] = sumWidth - wordSpacing + rowOffsets[row - 1];
-      sumWidth = wordSpacing;
-    }
-
-    wordRowMap[i] = row;
   }
 
   // need to use style prop and perform CSS calc() operations in template

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -315,8 +315,6 @@ const TypingTest = () => {
           <p>typed errors: {typedErrors}</p>
           <p>width: {width}</p>
           <p>countdown: {countdown} s</p>
-          <p>row offsets: {JSON.stringify(rowOffsets)}</p>
-          <p>word row map: {JSON.stringify(wordRowMap)}</p>
         </div>
         {isTestDone && <h2>Test done!</h2>}
         <div>

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -25,20 +25,29 @@ const TypingTest = () => {
     'dog',
   ]);
 
+  const [wordIndex, setWordIndex] = useState(0);
+  const [letterIndex, setLetterIndex] = useState(0);
+  const [typedIndex, setTypedIndex] = useState(0);
+  const [isTestDone, setIsTestDone] = useState(false);
+  const [isTestStarted, setIsTestStarted] = useState(false);
+  const [time, setTime] = useState({
+    start: null,
+    end: null,
+  });
+  const [countdown, setCountdown] = useState(config.timedTestDuration);
+  const [typedCharacters, setTypedCharacters] = useState(0);
+  const [typedErrors, setTypedErrors] = useState(0);
+
+  const ref = useRef(null);
+  const [width, setWidth] = useState(0);
+
+  const [wordRowMap, setWordRowMap] = useState({});
+
   function getRandomWords(wordArray, targetNum) {
     let randomizedWords = [];
-    let visitedIndices = [];
 
-    const wordLimit = Math.min(wordArray.length, targetNum);
-
-    for (let i = 0; i < wordLimit; i++) {
+    for (let i = 0; i < targetNum; i++) {
       let index = Math.floor(Math.random() * wordArray.length);
-
-      while (visitedIndices.includes(index)) {
-        index = Math.floor(Math.random() * wordArray.length);
-      }
-
-      visitedIndices.push(index);
       randomizedWords.push(wordArray[index]);
     }
 
@@ -63,29 +72,21 @@ const TypingTest = () => {
     return wordArray;
   }
 
-  const [wordsObject, setWordsObject] = useState(mapWords(words));
+  const [wordsObject, setWordsObject] = useState(() => {
+    if (config.isTimedTest) {
+      return mapWords(getRandomWords(words, 500));
+    } else if (config.isWordsTest) {
+      return mapWords(getRandomWords(words, config.wordsTestTarget));
+    }
+  });
 
   useEffect(() => {
-    setWordsObject(mapWords(getRandomWords(words, config.wordsTestTarget)));
-  }, [words, config.wordsTestTarget]);
-
-  const [wordIndex, setWordIndex] = useState(0);
-  const [letterIndex, setLetterIndex] = useState(0);
-  const [typedIndex, setTypedIndex] = useState(0);
-  const [isTestDone, setIsTestDone] = useState(false);
-  const [isTestStarted, setIsTestStarted] = useState(false);
-  const [time, setTime] = useState({
-    start: null,
-    end: null,
-  });
-  const [countdown, setCountdown] = useState(config.timedTestDuration);
-  const [typedCharacters, setTypedCharacters] = useState(0);
-  const [typedErrors, setTypedErrors] = useState(0);
-
-  const ref = useRef(null);
-  const [width, setWidth] = useState(0);
-
-  const [wordRowMap, setWordRowMap] = useState({});
+    if (config.isTimedTest) {
+      setWordsObject(mapWords(getRandomWords(words, 500)));
+    } else if (config.isWordsTest) {
+      setWordsObject(mapWords(getRandomWords(words, config.wordsTestTarget)));
+    }
+  }, [words, config]);
 
   useEffect(() => {
     function handleKeydown(e) {
@@ -262,7 +263,11 @@ const TypingTest = () => {
     setCountdown(config.timedTestDuration);
     setTypedCharacters(0);
     setTypedErrors(0);
-    setWordsObject(mapWords(words));
+    if (config.isTimedTest) {
+      setWordsObject(mapWords(getRandomWords(words, 500)));
+    } else if (config.isWordsTest) {
+      setWordsObject(mapWords(getRandomWords(words, config.wordsTestTarget)));
+    }
   }
 
   const [rowOffsets, setRowOffsets] = useState({});

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -398,12 +398,12 @@ const TypingTest = () => {
         <p>config: {JSON.stringify(config)}</p>
         <p>words length: {words.length}</p>
         <p>word index: {wordIndex}</p>
-        <p>words object: {JSON.stringify(wordsObject)}</p>
+        {/* <p>words object: {JSON.stringify(wordsObject)}</p> */}
         <p>letter index: {letterIndex}</p>
         <p>typed: {wordsObject[wordIndex].typed}</p>
         <p>typed index: {typedIndex}</p>
-        <p>current word: {words[wordIndex]}</p>
-        <p>next letter: {words[wordIndex].charAt(letterIndex)}</p>
+        {/* <p>current word: {words[wordIndex]}</p>
+        <p>next letter: {words[wordIndex].charAt(letterIndex)}</p> */}
         <p>test done? {String(isTestDone)}</p>
         <p>start time: {JSON.stringify(time)} </p>
         <p>typed chars: {typedCharacters}</p>

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -85,6 +85,8 @@ const TypingTest = () => {
   const ref = useRef(null);
   const [width, setWidth] = useState(0);
 
+  const [wordRowMap, setWordRowMap] = useState({});
+
   useEffect(() => {
     function handleKeydown(e) {
       const currentWord = wordsObject[wordIndex].word;
@@ -245,6 +247,36 @@ const TypingTest = () => {
     }
   }
 
+  const [rowOffsets, setRowOffsets] = useState({});
+
+  useEffect(() => {
+    let row = 0;
+    let sumWidth = 0;
+
+    let rowOffsetsTemp = { 0: 0 };
+    let wordRowMapTemp = {};
+
+    for (let i = 0; i < wordsObject.length; i++) {
+      const wordLength = Math.max(
+        wordsObject[i].word.length,
+        wordsObject[i].typed.length,
+      );
+      const wordSpacing = (wordLength + 1) * 14.4; // 14.4px per character + one space
+      sumWidth += wordSpacing;
+
+      if (sumWidth > width) {
+        row += 1;
+        rowOffsetsTemp[row] = sumWidth - wordSpacing + rowOffsetsTemp[row - 1];
+        sumWidth = wordSpacing;
+      }
+
+      wordRowMapTemp[i] = row;
+    }
+
+    setRowOffsets(rowOffsetsTemp);
+    setWordRowMap(wordRowMapTemp);
+  }, [width]);
+
   return (
     <>
       <div className="flex flex-col justify-center items-center">
@@ -265,6 +297,8 @@ const TypingTest = () => {
           <p>typed errors: {typedErrors}</p>
           <p>width: {width}</p>
           <p>countdown: {countdown} s</p>
+          <p>row offsets: {JSON.stringify(rowOffsets)}</p>
+          <p>word row map: {JSON.stringify(wordRowMap)}</p>
         </div>
         {isTestDone && <h2>Test done!</h2>}
         <div>
@@ -320,7 +354,8 @@ const TypingTest = () => {
             wordsObject={wordsObject}
             wordIndex={wordIndex}
             letterIndex={letterIndex}
-            containerWidth={width}
+            wordRowMap={wordRowMap}
+            rowOffsets={rowOffsets}
           />
           {wordsObject.map((wordObject, index) => {
             return (

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -238,13 +238,31 @@ const TypingTest = () => {
         timedTestDuration: e.target.getAttribute('duration'),
       });
       setCountdown(Number(e.target.getAttribute('duration')));
+      resetTest();
     }
     if (config.isWordsTest) {
       setConfig({ ...config, wordsTestTarget: e.target.getAttribute('words') });
       setWordsObject(
         mapWords(getRandomWords(words, e.target.getAttribute('words'))),
       );
+      resetTest();
     }
+  }
+
+  function resetTest() {
+    setWordIndex(0);
+    setLetterIndex(0);
+    setTypedIndex(0);
+    setIsTestDone(false);
+    setIsTestStarted(false);
+    setTime({
+      start: null,
+      end: null,
+    });
+    setCountdown(config.timedTestDuration);
+    setTypedCharacters(0);
+    setTypedErrors(0);
+    setWordsObject(mapWords(words));
   }
 
   const [rowOffsets, setRowOffsets] = useState({});
@@ -301,6 +319,15 @@ const TypingTest = () => {
           <p>word row map: {JSON.stringify(wordRowMap)}</p>
         </div>
         {isTestDone && <h2>Test done!</h2>}
+        <div>
+          <button
+            type="button"
+            className="border rounded bg-blue-500 hover:bg-blue-700 text-white p-2"
+            onClick={resetTest}
+          >
+            reset
+          </button>
+        </div>
         <div>
           <button
             type="button"

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -293,7 +293,7 @@ const TypingTest = () => {
 
     setRowOffsets(rowOffsetsTemp);
     setWordRowMap(wordRowMapTemp);
-  }, [width]);
+  }, [width, wordsObject]);
 
   return (
     <>

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -108,7 +108,7 @@ const TypingTest = () => {
         let newWordIndex = wordIndex + 1;
 
         // if already on last word, end typing test
-        if (newWordIndex >= wordsObject.length) {
+        if (newWordIndex >= wordsObject.length && config.isWordsTest) {
           setIsTestDone(true);
           setTime({ ...time, end: new Date() });
           return;
@@ -158,7 +158,8 @@ const TypingTest = () => {
         // if user on last word and typed word matches, end typing test
         if (
           wordIndex === wordsObject.length - 1 &&
-          newWordsObject[wordIndex].typed === currentWord
+          newWordsObject[wordIndex].typed === currentWord &&
+          config.isWordsTest
         ) {
           setIsTestDone(true);
           setTime({ ...time, end: new Date() });

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -298,25 +298,6 @@ const TypingTest = () => {
   return (
     <>
       <div className="flex flex-col justify-center items-center">
-        <h2>Debug Info</h2>
-        <div>
-          <p>config: {JSON.stringify(config)}</p>
-          <p>words length: {words.length}</p>
-          <p>word index: {wordIndex}</p>
-          <p>words object: {JSON.stringify(wordsObject)}</p>
-          <p>letter index: {letterIndex}</p>
-          <p>typed: {wordsObject[wordIndex].typed}</p>
-          <p>typed index: {typedIndex}</p>
-          <p>current word: {words[wordIndex]}</p>
-          <p>next letter: {words[wordIndex].charAt(letterIndex)}</p>
-          <p>test done? {String(isTestDone)}</p>
-          <p>start time: {JSON.stringify(time)} </p>
-          <p>typed chars: {typedCharacters}</p>
-          <p>typed errors: {typedErrors}</p>
-          <p>width: {width}</p>
-          <p>countdown: {countdown} s</p>
-        </div>
-        {isTestDone && <h2>Test done!</h2>}
         <div>
           <button
             type="button"
@@ -395,6 +376,7 @@ const TypingTest = () => {
             );
           })}
         </div>
+        {isTestDone && <h2>Test done!</h2>}
         {isTestDone && (
           <Stats
             wordsObject={wordsObject}
@@ -404,6 +386,24 @@ const TypingTest = () => {
             endTime={time.end}
           />
         )}
+      </div>
+      <h2>Debug Info</h2>
+      <div>
+        <p>config: {JSON.stringify(config)}</p>
+        <p>words length: {words.length}</p>
+        <p>word index: {wordIndex}</p>
+        <p>words object: {JSON.stringify(wordsObject)}</p>
+        <p>letter index: {letterIndex}</p>
+        <p>typed: {wordsObject[wordIndex].typed}</p>
+        <p>typed index: {typedIndex}</p>
+        <p>current word: {words[wordIndex]}</p>
+        <p>next letter: {words[wordIndex].charAt(letterIndex)}</p>
+        <p>test done? {String(isTestDone)}</p>
+        <p>start time: {JSON.stringify(time)} </p>
+        <p>typed chars: {typedCharacters}</p>
+        <p>typed errors: {typedErrors}</p>
+        <p>width: {width}</p>
+        <p>countdown: {countdown} s</p>
       </div>
     </>
   );

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -388,6 +388,9 @@ const TypingTest = () => {
                 key={index}
                 word={wordObject.word}
                 typed={wordObject.typed}
+                index={index}
+                wordIndex={wordIndex}
+                wordRowMap={wordRowMap}
               />
             );
           })}

--- a/frontend/src/components/Word.jsx
+++ b/frontend/src/components/Word.jsx
@@ -44,7 +44,9 @@ export default function Word({ word, typed, index, wordIndex, wordRowMap }) {
 
   return (
     <>
-      <div className="text-2xl font-mono mr-[14.4px]">{renderLetters()}</div>
+      {renderLetters() !== null && (
+        <div className="text-2xl font-mono mr-[14.4px]">{renderLetters()}</div>
+      )}
     </>
   );
 }

--- a/frontend/src/components/Word.jsx
+++ b/frontend/src/components/Word.jsx
@@ -1,9 +1,22 @@
 import Letter from './Letter';
 
-export default function Word({ word, typed }) {
+export default function Word({ word, typed, index, wordIndex, wordRowMap }) {
   const maxLength = Math.max(word.length, typed.length);
 
   const renderLetters = () => {
+    const wordRow = wordRowMap[index];
+    const currentRow = wordRowMap[wordIndex];
+
+    if (currentRow === 0) {
+      if (wordRow > currentRow + 2) {
+        return null;
+      }
+    } else {
+      if (wordRow < currentRow - 1 || wordRow > currentRow + 1) {
+        return null;
+      }
+    }
+
     let letterArray = [];
 
     for (let i = 0; i < maxLength; i++) {


### PR DESCRIPTION
## Changes

### Major Changes
Changes made to address issue #14.

Update how `wordsObject` is populated to support a minimum number of words for timed tests so that the user doesn't run out of words to type. Limit the typing window to a maximum of 3 rows of words at any given time. Hoist word-row map and row offset calculations out of `Cursor.jsx` and up to parent since this info is now passed to `Word.jsx` as well. It is still passed to `Cursor.jsx`, which now stays centered on the second (middle) row for all cases unless the user is typing the very first row.

### Bug Fixes / Minor Changes
- Fix unnecessary spacing of null `Word.jsx` objects (resulting from margin on div) by making render of entire div conditional
- Some debug info commented out that was causing odd behavior and crashes when certain state variables were updated
- Add reset button that resets all relevant state variables in preparation for a repeat of the configured typing test

## Why
See issue #14.

## How
The word row map determines the row that any given word will be in based on the width of its characters and following spaces in comparison to the width of the typing window. The row offset provides the horizontal adjustment needed to bring the cursor back to the beginning of a row when moving from one row to the next (like a typical typing cursor moving in a text editor).

These two data structures are also used for `Word.jsx` now to determine for a given word, whether it was previously typed, is the one the user is currently typing, or is an upcoming word, is conditionally rendered depending on what row the user is on. By default, only 3 rows are shown, so only the row before and the row after the user's current row are considered.

## Notes
Originally I attempted to have words added to `wordsObject` for a timed test on demand i.e. start with, say, 50 words, and if the test is ongoing and they're less than 25 words away from reaching the end of what's available in `wordsObject`, add more. This led to some odd behavior when updating things.

In the end, it seemed easier to just assume nobody can type faster than 250 WPM, so for a maximum of a 120 s (2 min) test, 500 words on average would be more than enough to assure the user doesn't run out of words as they complete a timed test.