### PR TITLE
Fix accuracy calcs

### DIFF
--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -4,6 +4,7 @@ export default function Stats({
   countErrors,
   timeStart,
   timeEnd,
+  isTimeMode,
 }) {
   let errors = 0;
   let extras = 0;
@@ -12,6 +13,8 @@ export default function Stats({
   for (const entry of tracker) {
     const word = entry.expected;
     const typed = entry.typed;
+
+    if (isTimeMode && typed === '') continue;
 
     const maxLength = Math.max(word.length, typed.length);
 

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -450,6 +450,7 @@ const TypingTest = () => {
               countErrors={count.errors}
               timeStart={time.start}
               timeEnd={time.end}
+              isTimeMode={config.isTimeMode}
             />
           </section>
         )}

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -88,7 +88,7 @@ const TypingTest = () => {
 
   const [tracker, setTracker] = useState(() => {
     if (config.isTimeMode) {
-      return mapWords(getRandomWords(wordList, 25));
+      return mapWords(getRandomWords(wordList, 500));
     } else if (config.isWordMode) {
       return mapWords(getRandomWords(wordList, config.wordModeCount));
     }
@@ -96,7 +96,7 @@ const TypingTest = () => {
 
   useEffect(() => {
     if (config.isTimeMode) {
-      setTracker(mapWords(getRandomWords(wordList, 25)));
+      setTracker(mapWords(getRandomWords(wordList, 500)));
     } else if (config.isWordMode) {
       setTracker(mapWords(getRandomWords(wordList, config.wordModeCount)));
     }
@@ -303,7 +303,7 @@ const TypingTest = () => {
       typed: 0,
       errors: 0,
     });
-    setTracker(mapWords(getRandomWords(wordList, 25)));
+    setTracker(mapWords(getRandomWords(wordList, 500)));
   }
 
   function resetWordMode(num) {

--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -104,6 +104,13 @@ const TypingTest = () => {
 
   useEffect(() => {
     function handleKeydown(e) {
+      if (status.isDone) {
+        if (e.key === 'Enter') {
+          handleReset();
+        }
+        return;
+      }
+
       const currentWord = tracker[index.word].expected;
       const expectedLetter = tracker[index.word].expected.charAt(index.letter);
       const alphaLower = 'abcdefghijklmnopqrstuvwxyz';


### PR DESCRIPTION
## Changes

### Major Changes
Fixes issue #15.

Updates accuracy calculations for timed tests so that words not encountered are not considered (before, they were being counted as missing letters).

### Bug Fixes / Minor Changes
- Fix number of words in timed test to be set to 500 by default; this typo was leftover from the major refactor of the code

## Why
Accuracy calculations were the same for timed and word mode tests, but a timed test should not consider words and letters not encountered.

## How
Including the config `isTimeMode` boolean in the parameters for the `Stats.jsx` component so that it can determine whether to consider a word or skip it if it has been encountered or not.

## Notes
Technically the way the calculations are performed, if somebody typed the first letter of a very long word and the timer ended, the user would be penalized for all the letters they didn't type in that word. This is supposed to account for letters missed in previously typed words, but this would wrongly penalize the user near the end of the test.

I don't have a good solution for this yet. But it is a minor issue in comparison to the issue that this PR seeks to fix.