### PR TITLE
Fix spacebar bug

### DIFF
--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -104,6 +104,8 @@ const TypingTest = () => {
 
   useEffect(() => {
     function handleKeydown(e) {
+      e.preventDefault();
+
       if (status.isDone) {
         if (e.key === 'Enter') {
           handleReset();


### PR DESCRIPTION
## Changes

### Major Changes
Fixes issue #16.

Adds `event.preventDefault()` to the keydown event handler function to avoid the spacebar keydown bug.

### Bug Fixes / Minor Changes
N/A

## Why
Button presses focus the button, so subsequent presses of spacebar would press the button again if the user was configuring test options with the buttons in the options section.

## How
`event.preventDefault()` to ignore the default behavior of the spacebar.

## Notes
Preventing default behavior may have some impact on keyboard accessibility for navigation or similar browser functions. This may need to be revisited if it becomes more of an issue.