### PR TITLE
Add tooltips to statistics window

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.38",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-tooltip": "^5.27.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -822,6 +823,28 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+      "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
+      "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1756,6 +1779,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -4208,6 +4236,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.27.0.tgz",
+      "integrity": "sha512-JXROcdfCEbCqkAkh8LyTSP3guQ0dG53iY2E2o4fw3D8clKzziMpE6QG6CclDaHELEKTzpMSeAOsdtg0ahoQosw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-tooltip": "^5.27.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -42,22 +42,63 @@ export default function Stats({
     <>
       <div className="grid grid-cols-2 text-2xl gap-x-6">
         <p className="text-sky-300/50">characters:</p>
-        <p className="text-sky-200">
-          {countTyped}/{errors}/{extras}/{missed}
-        </p>
+        <a
+          data-tooltip-id="character"
+          data-tooltip-content="correct/error/extra/missed"
+        >
+          <p className="text-sky-200">
+            {countTyped}/{errors}/{extras}/{missed}
+          </p>
+        </a>
+        <Tooltip id="character" place="right" />
 
         <p className="text-sky-300/50">raw wpm:</p>
-        <p className="text-sky-200"> {rawWpm}</p>
+        <a
+          data-tooltip-id="rawWpm"
+          data-tooltip-content={`${rawWpm.toFixed(2)} wpm`}
+        >
+          <p className="text-sky-200"> {Math.round(rawWpm)}</p>
+        </a>
+        <Tooltip id="rawWpm" place="right" />
 
         <p className="text-sky-300/50">net wpm:</p>
-        {netWpm > 0 && <p className="text-sky-200">{netWpm}</p>}
-        {netWpm <= 0 && <p className="text-sky-200">invalid</p>}
+        {netWpm > 0 && (
+          <>
+            <a
+              data-tooltip-id="netWpm"
+              data-tooltip-content={`${netWpm.toFixed(2)} wpm`}
+            >
+              <p className="text-sky-200">{Math.round(netWpm)}</p>
+            </a>
+            <Tooltip id="netWpm" place="right" />
+          </>
+        )}
+        {netWpm <= 0 && (
+          <>
+            <a data-tooltip-id="invalid" data-tooltip-content="invalid">
+              <p className="text-sky-200">invalid</p>
+            </a>
+            <Tooltip id="invalid" place="right" />
+          </>
+        )}
 
         <p className="text-sky-300/50">accuracy:</p>
-        <p className="text-sky-200">{percentAccuracy}%</p>
+        <a
+          data-tooltip-id="percentAccuracy"
+          data-tooltip-content={`${percentAccuracy.toFixed(2)}%`}
+        >
+          <p className="text-sky-200">{Math.round(percentAccuracy)}%</p>
+        </a>
+        <Tooltip id="percentAccuracy" place="right" />
 
         <p className="text-sky-300/50">duration:</p>
-        <p className="text-sky-200">{Math.round(duration * 60)}s</p>
+        <a
+          data-tooltip-id="duration"
+          data-tooltip-content={`${(duration * 60).toFixed(2)}s`}
+        >
+          <p className="text-sky-200">{Math.round(duration * 60)}s</p>
+        </a>
+        <Tooltip id="duration" place="right" />
       </div>
     </>
   );

--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -40,7 +40,7 @@ export default function Stats({
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-x-6">
+      <div className="grid grid-cols-2 text-2xl gap-x-6">
         <p className="text-sky-300/50">characters:</p>
         <p className="text-sky-200">
           {countTyped}/{errors}/{extras}/{missed}

--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -1,3 +1,5 @@
+import { Tooltip } from 'react-tooltip';
+
 export default function Stats({
   tracker,
   countTyped,
@@ -31,11 +33,10 @@ export default function Stats({
 
   const wordsTyped = countTyped / 5; // standard to consider a 'word' to be any 5 characters
   const duration = (timeEnd.getTime() - timeStart.getTime()) / 1000 / 60; // ms converted to min
-  const rawWpm = Math.round(wordsTyped / duration);
-  const netWpm = Math.round((wordsTyped - errors - extras - missed) / duration);
-  const percentAccuracy = Math.round(
-    ((countTyped - countErrors - extras - missed) / countTyped) * 100,
-  );
+  const rawWpm = wordsTyped / duration;
+  const netWpm = (wordsTyped - errors - extras - missed) / duration;
+  const percentAccuracy =
+    ((countTyped - countErrors - extras - missed) / countTyped) * 100;
 
   return (
     <>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './styles/index.css';
+import 'react-tooltip/dist/react-tooltip.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Changes

### Major Changes
Adds tooltips from react-tooltip to the statistics window. The tooltips clarify info or provide numerical values with more precision (2 decimal places).

### Bug Fixes / Minor Changes
- Remove `Math.round()` calls in calculations of metrics like WPM and accuracy, and instead call it for each given value when rendering the JSX. This allows for reuse of the variable when using `toFixed()` to round floats to a desired precision for the tooltips.

## Why
Keeps a minimal interface at-a-glance, but provides some feedback to the user if they decide to hover over it.

## How
Use of the react-tooltip library.

## Notes
N/A