### PR TITLE
Add config checks to prevent unnecessary reloads

### DIFF
--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -71,13 +71,16 @@ const TypingTest = () => {
   }
 
   async function handleGetWordList(e) {
+    const listName = e.target.getAttribute('list');
+
+    if (config.wordList === listName) return;
+
     setStatus({
       isStarted: false,
       isDone: false,
       isLoading: true,
     });
 
-    const listName = e.target.getAttribute('list');
     await fetch(`http://localhost:3000/${listName}`)
       .then((res) => res.json())
       .then((data) => {
@@ -270,9 +273,12 @@ const TypingTest = () => {
 
   function handleTestMode(e) {
     const testMode = e.target.getAttribute('mode');
+
     if (testMode === 'time') {
+      if (config.isTimeMode) return;
       setConfig({ ...config, isTimeMode: true, isWordMode: false });
     } else if (testMode === 'word') {
+      if (config.isWordMode) return;
       setConfig({ ...config, isTimeMode: false, isWordMode: true });
     }
     setTypingWindowKey(Math.random());
@@ -282,6 +288,8 @@ const TypingTest = () => {
     if (config.isTimeMode) {
       const duration = Number(e.target.getAttribute('duration'));
 
+      if (config.timeModeDuration === duration) return;
+
       setConfig({
         ...config,
         timeModeDuration: duration,
@@ -290,6 +298,8 @@ const TypingTest = () => {
       resetTimeMode(duration);
     } else if (config.isWordMode) {
       const num = Number(e.target.getAttribute('count'));
+
+      if (config.wordModeCount === num) return;
 
       setConfig({
         ...config,


### PR DESCRIPTION
## Changes

### Major Changes
Adds checks in config handler functions to return from the function if the button being clicked on matches the current config. For example, if a timed test has 15s specified, clicking on the 15s button again will do nothing. This has been implemented for time vs. word mode, duration, word count, and word lists.

### Bug Fixes / Minor Changes
N/A

## Why
Clicking on the same button as the config that's currently active would force a reload of everything. This is unnecessary, so adding in a basic check of the config can prevent it.

## How
Basic conditional of whether the button being pressed matches the current config, and if it does, do nothing and return to save the user the reload.

## Notes
N/A