### PR TITLE
Add kbd tag to indicate reset shortcut at end of test

### DIFF
--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -492,16 +492,25 @@ const TypingTest = () => {
           </div>
         </section>
         {status.isDone && (
-          <section>
-            <Stats
-              tracker={tracker}
-              countTyped={count.typed}
-              countErrors={count.errors}
-              timeStart={time.start}
-              timeEnd={time.end}
-              isTimeMode={config.isTimeMode}
-            />
-          </section>
+          <>
+            <p className="flex items-center gap-2 my-4">
+              type
+              <kbd className="rounded text-sky-950 bg-sky-300/50 p-0.5">
+                enter
+              </kbd>
+              to reset
+            </p>
+            <section>
+              <Stats
+                tracker={tracker}
+                countTyped={count.typed}
+                countErrors={count.errors}
+                timeStart={time.start}
+                timeEnd={time.end}
+                isTimeMode={config.isTimeMode}
+              />
+            </section>
+          </>
         )}
       </div>
     </>


### PR DESCRIPTION
## Changes

### Major Changes
Adds a message letting the user know that they can press the enter key to reset at the end of a test.

### Bug Fixes / Minor Changes
N/A

## Why
Without a message like this somewhere, the user wouldn't know they can do this.

## How
N/A

## Notes
N/A