### PR TITLE
Set up localStorage save and retrieve for config

### DIFF
--- a/frontend/src/components/TypingTest.jsx
+++ b/frontend/src/components/TypingTest.jsx
@@ -7,13 +7,23 @@ import ModeButton from './buttons/ModeButton.jsx';
 import WordListButton from './buttons/WordListButton.jsx';
 
 const TypingTest = () => {
-  const [config, setConfig] = useState({
-    isTimeMode: true,
-    timeModeDuration: 15, // seconds
-    isWordMode: false,
-    wordModeCount: 25,
-    wordList: 'default',
+  const [config, setConfig] = useState(() => {
+    if (window.localStorage.getItem('yubi') === null) {
+      return {
+        isTimeMode: true,
+        timeModeDuration: 15, // seconds
+        isWordMode: false,
+        wordModeCount: 25,
+        wordList: 'default',
+      };
+    } else {
+      return JSON.parse(window.localStorage.getItem('yubi'));
+    }
   });
+
+  useEffect(() => {
+    window.localStorage.setItem('yubi', JSON.stringify(config));
+  }, [config]);
 
   const [wordList, setWordList] = useState([
     'the',


### PR DESCRIPTION
## Changes

### Major Changes
Sets up storage of the config object in localStorage as well as automatic updates to the localStorage value when the config changes.

### Bug Fixes / Minor Changes
N/A

## Why
It is nice if the user's configuration is saved between sessions and localStorage is a convenient place for it.

## How
Check if the key in localStorage exists and if it does, set the config to the parsed JSON. If it doesn't exist, assign the default config. Use the useEffect hook with a dependency on the config to update the localStorage value as needed.

## Notes
With a possibly fetched word list specified in the stored config, the word list should now be populated with a fetch request. However, attempting to do so leads to some errors. This should be investigated, but for now, it at least saves the config...it just forces the default word list on the user to start.