### PR TITLE
Update API request paths

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -7,7 +7,7 @@ import cors from 'cors';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-import indexRouter from './routes/index.js';
+import wordgroupsRouter from './routes/wordgroups.js';
 import { fileURLToPath } from 'url';
 
 const app = express();
@@ -23,6 +23,6 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', indexRouter);
+app.use('/api/wordgroups', wordgroupsRouter);
 
 export default app;

--- a/backend/routes/wordgroups.js
+++ b/backend/routes/wordgroups.js
@@ -53,4 +53,5 @@ router.get('/subtitles-5k', function (req, res, next) {
 router.get('/wikipedia-100', function (req, res, next) {
   res.sendFile(path.join(__dirname, '../data/wikipedia-100.json'));
 });
+
 export default router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,7 +53,7 @@ function App() {
 
   useEffect(() => {
     async function fetchWordList() {
-      await fetch(`http://localhost:3000/${wordGroup}`)
+      await fetch(`http://localhost:3000/api/wordgroups/${wordGroup}`)
         .then((res) => res.json())
         .then((data) => {
           setWords(data.words);


### PR DESCRIPTION
## Changes

### Major Changes
Path for API requests to the backend reconfigured to have `api` in the path as well as further organization by categorizing all word groups under the `wordgroup` path, making the full path `/api/wordgroups` with the desired word group name as the final component of the path. Routers have been reconfigured in the backend code and the frontend fetch request was updated as well.

### Bug Fixes / Minor Changes
- Miscellaneous formatting

## Why
The API endpoint up until now was temporary, but with a rename, it is more finalized as well as more RESTful.

## How
See above.

## Notes
N/A