### PR TITLE
Fix accessibility of typing window

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -358,6 +358,7 @@ function App() {
       <div
         className="flex flex-col items-center min-w-80 font-mono text-sky-300/50"
         onKeyDown={handleKeyDownReset}
+        tabIndex="0"
       >
         <Header />
         <ConfigMenu

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -355,7 +355,10 @@ function App() {
 
   return (
     <>
-      <div className="flex flex-col items-center min-w-80 font-mono text-sky-300/50">
+      <div
+        className="flex flex-col items-center min-w-80 font-mono text-sky-300/50"
+        onKeyDown={handleKeyDownReset}
+      >
         <Header />
         <ConfigMenu
           config={config}
@@ -380,6 +383,7 @@ function App() {
               tracker={tracker}
               index={index}
               typingAreaKey={typingAreaKey}
+              onKeyDown={handleKeyDown}
             />
           </>
         )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -79,127 +79,123 @@ function App() {
     }
   }, [words, config]);
 
-  useEffect(() => {
-    function handleKeydown(e) {
+  function handleKeyDown(e) {
+    const currentWord = tracker[index.word].expected;
+    const expectedLetter = tracker[index.word].expected.charAt(index.letter);
+    const alphaLower = "abcdefghijklmnopqrstuvwxyz'";
+
+    if (alphaLower.includes(e.key)) {
       e.preventDefault();
+    }
 
-      if (status.isDone) {
-        if (e.key === 'Enter') {
-          handleReset();
-        }
-        return;
-      }
+    // updates to tracker, index, and count states depend on the condition
+    // below, so instantiate only once here, then edit and update state
+    // if needed
+    let trackerNew = [...tracker];
+    let indexNew = { ...index };
+    let countNew = { ...count };
 
-      const currentWord = tracker[index.word].expected;
-      const expectedLetter = tracker[index.word].expected.charAt(index.letter);
-      const alphaLower = 'abcdefghijklmnopqrstuvwxyz';
+    if (!status.isStarted) {
+      setStatus({ ...status, isStarted: true });
+      setTime({ ...time, start: new Date() });
+    }
 
-      // updates to tracker, index, and count states depend on the condition
-      // below, so instantiate only once here, then edit and update state
-      // if needed
-      let trackerNew = [...tracker];
-      let indexNew = { ...index };
-      let countNew = { ...count };
-
-      if (!status.isStarted) {
-        setStatus({ ...status, isStarted: true });
-        setTime({ ...time, start: new Date() });
-      }
-
-      // if user types space at start of word, do nothing
-      if (e.key === ' ' && index.typed === 0) {
-        return;
-      }
-
-      // if user types space anywhere else, go to next word
-      if (e.key === ' ' && index.typed > 0) {
-        let indexNextWord = index.word + 1;
-
-        // if already on last word, end typing test
-        if (indexNextWord >= tracker.length && config.isWordMode) {
-          setStatus({ ...status, isDone: true });
-          setTime({ ...time, end: new Date() });
-          return;
-        }
-
-        setIndex({
-          word: indexNextWord,
-          letter: 0,
-          typed: 0,
-        });
-
-        setCount({ ...count, typed: count.typed + 1 });
-
-        return;
-      }
-
-      // if user types backspace, remove previously typed character
-      if (e.key === 'Backspace') {
-        trackerNew[index.word].typed = trackerNew[index.word].typed.slice(
-          0,
-          -1,
-        );
-
-        if (index.letter > 0) {
-          indexNew.typed -= 1;
-          indexNew.letter -= 1;
-        }
-
-        setIndex(indexNew);
-        setTracker(trackerNew);
-
-        return;
-      }
-
-      // handle all other user keypresses
-      if (e.key === expectedLetter) {
-        indexNew.letter += 1;
-        indexNew.typed += 1;
-
-        trackerNew[index.word].typed += e.key;
-
-        setTracker(trackerNew);
-        setIndex(indexNew);
-        setCount({ ...count, typed: count.typed + 1 });
-
-        // if user on last word and typed word matches, end typing test
-        if (
-          index.word === tracker.length - 1 &&
-          trackerNew[index.word].typed === currentWord &&
-          config.isWordMode
-        ) {
-          setStatus({ ...status, isDone: true });
-          setTime({ ...time, end: new Date() });
-          return;
-        }
-
-        // if word not finished, set letter and its index
-        if (indexNew.letter <= currentWord.length) {
-          setIndex(indexNew);
-          return;
-        }
-
-        // even if keypress was wrong, capture what user typed
-      } else if (alphaLower.includes(e.key)) {
-        indexNew.letter += 1;
-        indexNew.typed += 1;
-        trackerNew[index.word].typed += e.key;
-        countNew.expected += 1;
-        countNew.errors += 1;
-
-        setTracker(trackerNew);
-        setIndex(indexNew);
-        setCount(countNew);
-      }
+    // if user types space at start of word, do nothing
+    if (e.key === ' ' && index.typed === 0) {
       return;
     }
 
-    window.addEventListener('keydown', handleKeydown);
+    // if user types space anywhere else, go to next word
+    if (e.key === ' ' && index.typed > 0) {
+      let indexNextWord = index.word + 1;
 
-    return () => {
-      window.removeEventListener('keydown', handleKeydown);
-    };
-  }, [config, index, status, time, count, tracker]);
+      // if already on last word, end typing test
+      if (indexNextWord >= tracker.length && config.isWordMode) {
+        setStatus({ ...status, isDone: true });
+        setTime({ ...time, end: new Date() });
+        return;
+      }
+
+      setIndex({
+        word: indexNextWord,
+        letter: 0,
+        typed: 0,
+      });
+
+      setCount({ ...count, typed: count.typed + 1 });
+
+      return;
+    }
+
+    // if user types backspace, remove previously typed character
+    if (e.key === 'Backspace') {
+      trackerNew[index.word].typed = trackerNew[index.word].typed.slice(
+        0,
+        -1,
+      );
+
+      if (index.letter > 0) {
+        indexNew.typed -= 1;
+        indexNew.letter -= 1;
+      }
+
+      setIndex(indexNew);
+      setTracker(trackerNew);
+
+      return;
+    }
+
+    // handle all other user keypresses
+    if (e.key === expectedLetter) {
+      indexNew.letter += 1;
+      indexNew.typed += 1;
+
+      trackerNew[index.word].typed += e.key;
+
+      setTracker(trackerNew);
+      setIndex(indexNew);
+      setCount({ ...count, typed: count.typed + 1 });
+
+      // if user on last word and typed word matches, end typing test
+      if (
+        index.word === tracker.length - 1 &&
+        trackerNew[index.word].typed === currentWord &&
+        config.isWordMode
+      ) {
+        setStatus({ ...status, isDone: true });
+        setTime({ ...time, end: new Date() });
+        return;
+      }
+
+      // if word not finished, set letter and its index
+      if (indexNew.letter <= currentWord.length) {
+        setIndex(indexNew);
+        return;
+      }
+
+      // even if keypress was wrong, capture what user typed
+    } else if (alphaLower.includes(e.key)) {
+      indexNew.letter += 1;
+      indexNew.typed += 1;
+      trackerNew[index.word].typed += e.key;
+      countNew.expected += 1;
+      countNew.errors += 1;
+
+      setTracker(trackerNew);
+      setIndex(indexNew);
+      setCount(countNew);
+    }
+    return;
+  }
+
+  function handleKeyDownReset(e) {
+    if (status.isDone) {
+      if (e.key === 'Enter') {
+        handleReset();
+      }
+      return;
+    }
+  }
 
   useEffect(() => {
     const intervalId = setInterval(() => {

--- a/frontend/src/components/StatusBar.jsx
+++ b/frontend/src/components/StatusBar.jsx
@@ -9,7 +9,7 @@ export default function StatusBar({
   return (
     <div className="mt-8 mb-4">
       {!status.isStarted && !isLoading && (
-        <p className="animate-fadein text-2xl">type to begin</p>
+        <p className="animate-fadein text-2xl">focus, then type to begin</p>
       )}
       {config.isWordMode &&
         status.isStarted &&

--- a/frontend/src/components/TypingArea.jsx
+++ b/frontend/src/components/TypingArea.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import Word from './Word';
 import Caret from './Caret.jsx';
 
-export default function TypingTest({ status, tracker, index, typingAreaKey }) {
+export default function TypingTest({ status, tracker, index, typingAreaKey, onKeyDown }) {
   const ref = useRef(null);
   const [width, setWidth] = useState(0);
   const [wordRowMap, setWordRowMap] = useState({});
@@ -57,6 +57,8 @@ export default function TypingTest({ status, tracker, index, typingAreaKey }) {
           ref={ref}
           className="relative flex justify-start content-start flex-wrap max-w-3xl min-h-32 animate-fadein"
           style={{ visibility: status.isLoading ? 'hidden' : 'visible' }}
+          onKeyDown={onKeyDown}
+          tabIndex="0"
         >
           {!status.isDone && (
             <Caret

--- a/frontend/src/components/TypingArea.jsx
+++ b/frontend/src/components/TypingArea.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { FaArrowPointer } from "react-icons/fa6";
 import Word from './Word';
 import Caret from './Caret.jsx';
 
@@ -55,7 +56,7 @@ export default function TypingTest({ status, tracker, index, typingAreaKey, onKe
         <div
           key={typingAreaKey}
           ref={ref}
-          className="relative flex justify-start content-start flex-wrap max-w-3xl min-h-32 animate-fadein"
+          className="peer relative flex justify-start content-start flex-wrap max-w-3xl min-h-32 animate-fadein blur focus:blur-none"
           style={{ visibility: status.isLoading ? 'hidden' : 'visible' }}
           onKeyDown={onKeyDown}
           tabIndex="0"
@@ -83,6 +84,7 @@ export default function TypingTest({ status, tracker, index, typingAreaKey, onKe
             );
           })}
         </div>
+        <p className="flex items-center gap-2 text-2xl text-sky-200 absolute pointer-events-none peer-focus:invisible"><FaArrowPointer /> Click here to focus</p>
       </section>
     </>
   );


### PR DESCRIPTION
## Changes

### Major Changes
Return accessibility to page, allowing for tabbing through links/buttons/areas.

### Bug Fixes / Minor Changes
- Some styling added to get the user to focus on the typing area in order to proceed with the typing test

## Why
Default key codes were prevented from being used to facilitate engaging in the typing test, but this interfered with accessibility since tabbing wouldn't move between links/buttons/areas.

## How
The main keydown function handler was moved out of the `useEffect` hook and an `onKeyDown` attribute was added to the typing area component (and propagated down into the component) to localize keydown event listening to the typing area component only.

## Notes
N/A