### PR TITLE
Move reset button

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import ConfigMenu from './components/ConfigMenu';
 import StatusBar from './components/StatusBar';
 import TypingArea from './components/TypingArea';
 import Results from './components/Results';
+import ResetButton from './components/ResetButton';
 
 function App() {
   const [config, setConfig] = useState(() => {
@@ -388,6 +389,7 @@ function App() {
             />
           </>
         )}
+        <ResetButton onClickReset={handleReset} />
         {!isLoading && status.isDone && (
           <>
             <Results

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -357,7 +357,7 @@ function App() {
   return (
     <>
       <div
-        className="flex flex-col items-center min-w-80 font-mono text-sky-300/50"
+        className="flex flex-col items-center min-w-80 min-h-dvh font-mono text-sky-300/50 mx-4"
         onKeyDown={handleKeyDownReset}
         tabIndex="0"
       >

--- a/frontend/src/components/Button.jsx
+++ b/frontend/src/components/Button.jsx
@@ -1,6 +1,7 @@
 export default function Button({
   onClick,
   isActive,
+  icon = null,
   text = null,
   mode = null,
   group = null,
@@ -12,25 +13,27 @@ export default function Button({
       {isActive ? (
         <button
           type="button"
-          className="bg-sky-950 text-sky-200 p-2"
+          className="flex items-center gap-2 bg-sky-950 text-sky-200 p-2"
           onClick={onClick}
           mode={mode}
           group={group}
           duration={duration}
           count={count}
         >
+          {icon}
           {text}
         </button>
       ) : (
         <button
           type="button"
-          className="bg-sky-950 text-sky-300/50 hover:text-sky-200 p-2"
+          className="flex items-center gap-2 bg-sky-950 text-sky-300/50 hover:text-sky-200 p-2"
           onClick={onClick}
           mode={mode}
           group={group}
           duration={duration}
           count={count}
         >
+          {icon}
           {text}
         </button>
       )}

--- a/frontend/src/components/ConfigMenu.jsx
+++ b/frontend/src/components/ConfigMenu.jsx
@@ -11,16 +11,17 @@ export default function ConfigMenu({
   return (
     <>
       <section className="flex flex-col gap-2 my-4">
-        <Button text={'reset'} onClick={onClickReset} isActive={false} />
         <div className="flex justify-center gap-4">
-          <div>
+          <div className="flex items-center">
             <Button
+              icon={<FaClock />}
               text={'time'}
               mode={'time'}
               onClick={onClickMode}
               isActive={config.isTimeMode}
             />
             <Button
+              icon={<FaA />}
               text={'word'}
               mode={'word'}
               onClick={onClickMode}
@@ -28,7 +29,7 @@ export default function ConfigMenu({
             />
           </div>
           {config.isWordMode && (
-            <div>
+            <div className="flex items-center">
               <Button
                 text={'10'}
                 count={'10'}
@@ -56,7 +57,7 @@ export default function ConfigMenu({
             </div>
           )}
           {config.isTimeMode && (
-            <div>
+            <div className="flex items-center">
               <Button
                 text={'15'}
                 duration={'15'}

--- a/frontend/src/components/ConfigMenu.jsx
+++ b/frontend/src/components/ConfigMenu.jsx
@@ -1,9 +1,9 @@
+import { FaClock, FaA } from "react-icons/fa6";
 import Button from './Button';
 
 export default function ConfigMenu({
   config,
   wordGroup,
-  onClickReset,
   onClickMode,
   onClickConfig,
   onClickWordGroup,

--- a/frontend/src/components/ResetButton.jsx
+++ b/frontend/src/components/ResetButton.jsx
@@ -1,0 +1,15 @@
+import { FaArrowRotateLeft } from 'react-icons/fa6';
+import Button from './Button';
+
+export default function ResetButton({ onClickReset }) {
+  return (
+    <div className="mt-4 mb-8">
+      <Button
+        icon={<FaArrowRotateLeft />}
+        text='reset'
+        onClick={onClickReset}
+        isActive={false}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/TypingArea.jsx
+++ b/frontend/src/components/TypingArea.jsx
@@ -52,7 +52,7 @@ export default function TypingTest({ status, tracker, index, typingAreaKey, onKe
 
   return (
     <>
-      <section className="flex flex-col gap-2 justify-center items-center mt-4 mb-8">
+      <section className="flex flex-col gap-2 justify-center items-center my-4">
         <div
           key={typingAreaKey}
           ref={ref}


### PR DESCRIPTION
## Changes

### Major Changes
Move reset button out of top configuration menu to below the typing area for easier access.

### Bug Fixes / Minor Changes
- Minor styling updates to accommodate new reset button and its new location.

## Why
A reset button closer to the typing window means it can be accessed more easily with a single tab than having to backwards-tab through all the other UI elements.

## How
A new button component was created that makes use of the existing `Button` component, but also accepts the reset event handler as an attribute.

## Notes
N/A